### PR TITLE
Aylar-Babaei-HW.json

### DIFF
--- a/Aylar-GroupABM.json
+++ b/Aylar-GroupABM.json
@@ -1,0 +1,8 @@
+{ "data" : [
+  {"weigt" : 150.06, "date" : "April 1, 2015" },
+            {"weight" : 150.24, "date" : "April 2, 2015" },
+            {"weight" : 148.99, "date" : "April 3, 2015" },
+            {"weight" : 149.40, "date" : "April 4, 2015" },
+  ]
+}
+  

--- a/json-hw-ababaei
+++ b/json-hw-ababaei
@@ -1,0 +1,17 @@
+
+
+{
+"genes": [{
+"accession": "KJ891170",
+"name": "Synthetic construct Homo sapiens clone ccsbBroadEn_00564 FGR gene",
+"length": 1719
+}, {
+"accession": "NC_008558",
+"name": "Blackberry virus Y",
+"length": 10851
+}, {
+"accession": "CR542175",
+"name": "Homo sapiens full open reading frame cDNA clone RZPDo834B1024D for gene CYCS ",
+"length": 318
+}]
+}


### PR DESCRIPTION
{
	"genes": [{
		"accession": "KJ891170",
		"name": "Synthetic construct Homo sapiens clone ccsbBroadEn_00564 FGR gene",
		"length": 1719
	}, {
		"accession": "NC_008558",
		"name": "Blackberry virus Y",
		"length": 10851
	}, {
		"accession": "CR542175",
		"name": "Homo sapiens full open reading frame cDNA clone RZPDo834B1024D for gene CYCS ",
		"length": 318
	}]
}